### PR TITLE
Fix for ESX.GetPlayers() return type (server)

### DIFF
--- a/server/esx_server.d.ts
+++ b/server/esx_server.d.ts
@@ -36,7 +36,7 @@ export class ESXServer extends ESXCommon {
      * This function returns an array of all online players ID's.
      * You can use this to access each players data.
      */
-    GetPlayers(): ESXPlayer[];
+    GetPlayers(): number[];
 
     /**
      * This function registers a server callback.


### PR DESCRIPTION
ESX.GetPlayers() returns an array of server ids as a number on both client and server side, not a player object. See https://esx-org.github.io/es_extended/server/functions/getplayers/