### PR TITLE
fix: Only label is required for a menu in ESX

### DIFF
--- a/classes/esx_client_ui_menu_data.d.ts
+++ b/classes/esx_client_ui_menu_data.d.ts
@@ -3,7 +3,6 @@ export declare interface ESXClientUIMenuData {
     align: string,
     elements?: {
         label: string,
-        identifier?: string,
-        submit?(any?): void
+        [key: string]: any
     }[],
 }

--- a/classes/esx_client_ui_menu_data.d.ts
+++ b/classes/esx_client_ui_menu_data.d.ts
@@ -3,7 +3,7 @@ export declare interface ESXClientUIMenuData {
     align: string,
     elements?: {
         label: string,
-        identifier: string,
-        submit(any?): void
+        identifier?: string,
+        submit?(any?): void
     }[],
 }


### PR DESCRIPTION
Only label is required to display the text. Everything else is optional and is managed by the function that manages the data the item click

Example:
 ```js
   ESX.UI.Menu.Open("default", GetCurrentResourceName(), "example", {
        title: "Title",
        align: "top-left",
        elements: [
            {
                label: "Test",
                random_value: "deposit",
                random_int: 5,
            }
        ]
    }, (data, menu) => {
        TriggerServerEvent("sample_event", data.random_value, data.random_int)
        menu.close()
    }, (_, menu) => {
        menu.close()
    })
```